### PR TITLE
Proper Version Comparison for Launcher Updates

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -27,6 +27,7 @@ download-async = "0.10"
 async-trait = "0.1"
 json = "0.12"
 quick-xml = { version="0.23", features=["serialize"] }
+semver = "1.0.11"
 
 [build-dependencies]
 embed-resource = "1.6"

--- a/backend/src/handler.rs
+++ b/backend/src/handler.rs
@@ -24,6 +24,7 @@ use crate::sha2::Digest;
 use std::io::Write;
 use std::io::Read;
 use ini::Ini;
+use semver::{Version};
 
 /// The current launcher's version
 static VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -417,11 +418,22 @@ impl Handler {
           return Ok(());
         }
       }
+
       let launcher_version = version_information.clone().unwrap().launcher;
-      if VERSION != launcher_version.version {
-        crate::spawn_wrapper::spawn(move || -> Result<(), Error> {callback.call(None, &make_args!(launcher_version.version), None)?; Ok(()) });
-      } else {
-        crate::spawn_wrapper::spawn(move || -> Result<(), Error> {callback.call(None, &make_args!(Value::null()), None)?; Ok(()) });
+      let cargo_ver = Version::parse(VERSION).unwrap();
+
+      match Version::parse(&launcher_version.version) {
+          Ok(expected_launcher_version) => {
+            if cargo_ver < expected_launcher_version {
+              crate::spawn_wrapper::spawn(move || -> Result<(), Error> {callback.call(None, &make_args!(launcher_version.version), None)?; Ok(()) });
+            } else {
+              crate::spawn_wrapper::spawn(move || -> Result<(), Error> {callback.call(None, &make_args!(Value::null()), None)?; Ok(()) });
+            }
+          },
+          Err(error) => {
+            error!("Problem parsing the version from server: {:?}", error);
+            crate::spawn_wrapper::spawn(move || -> Result<(), Error> {callback.call(None, &make_args!(Value::null()), None)?; Ok(()) });
+          },
       }
       
       Ok::<(), Error>(())


### PR DESCRIPTION
When running locally, the package version will most likely be higher than the server's reported version. If this is the case, a launcher update window is *not* shown.

Before: 
![launcherver](https://user-images.githubusercontent.com/592749/178367206-41316b7b-3c2c-493e-b725-927aaecc4d24.png)