### PR TITLE
chore: bump actions-x/commit version in workflow

### DIFF
--- a/.github/workflows/release-minor.yml
+++ b/.github/workflows/release-minor.yml
@@ -45,7 +45,7 @@ jobs:
         path: backend/RenX-Launcher.zip
 
     - name: Git Commit/Push Changes
-      uses: actions-x/commit@v2
+      uses: actions-x/commit@v6
       with:
         message: Release minor version ${{ steps.minor_version.outputs.version }}
         files: backend/Cargo.toml


### PR DESCRIPTION
See https://github.com/actions-x/commit/issues/8 (and the project's readme). Bumping version should fix release